### PR TITLE
Fixs for Node 4 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "grunt-mocha-test": "^0.12.7"
   },
   "dependencies": {
-    "node-sass": "^2.1.0",
+    "node-sass": "^3.3.3",
     "css-parse": "^2.0.0",
     "yargs": "^3.16.1",
     "chalk": "^1.1.0",

--- a/stss.js
+++ b/stss.js
@@ -54,6 +54,9 @@ function process(stss, options, log) {
 				callback(css);
 				return;
 			}
+			if (css instanceof Buffer) {
+				css = css.toString();
+			}
 			log('css', css);
 			callback(null, css);
 		},
@@ -103,15 +106,16 @@ function processSync(stss, options, log) {
 	var scss = stss2scss(stss, options);
 	if (scss instanceof Error) { throw scss; }
 	log('scss', scss);
-	
+
 	var css = scss2css(scss, options);
 	if (css instanceof Error) { throw css; }
+	if (css instanceof Buffer) { css = css.toString(); }
 	log('css', css);
-	
+
 	var json = css2json(css, options);
 	if (json instanceof Error) { throw json; }
 	log('json', JSON.stringify(json, null, 2));
-	
+
 	var tss = json2tss(json, options);
 	if (tss instanceof Error) { throw tss; }
 	log('tss', tss);


### PR DESCRIPTION
Hello,

STSS had some bug since I upgraded from Node 0.12 to 4.X, it seems that upgrade `node-sass` and making a little check that I describe bellow resolved the issue.

The problem was that sometimes, css2json received `Buffer` instead of `String`, and `css-parse` give this variable to `css` without check.
I tried to make a pull request to the `css` package to make it allow the use of a Buffer or a String, you can see it here : https://github.com/reworkcss/css/pull/81 

It seems that making this fix in STSS is a better idea, according to the css package author.

Of course I launched a `npm test` and all passed with Node 4.2.1, so if you accept my PR I'll be able to work with an official fix instead my manually applied patch, and other STSS users will be able to work with your tool with the latest NodeJS version.

Thanks in advance!
Best regards,
Samuel D